### PR TITLE
Add check for no instances in ASG

### DIFF
--- a/src/tag_lambda/tag.py
+++ b/src/tag_lambda/tag.py
@@ -81,6 +81,10 @@ def handler(event, context):
     stack_name = event['StackName']
     instance_ids = get_instance_ids_by_tag(stack_name)
 
+    if not instance_ids:
+        logger.info('No instances to drain in this ASG, aborting operation')
+        return
+
     drain = event['Drain']
     set_drain_tag(instance_ids, drain)
 


### PR DESCRIPTION
Boto 3 throws an exception when trying to create tags when no instance ids are supplied, rightfully so. In the case of your ASG having no running instances, this exception would surface.

Added a check before draining instances so the lambda can exit gracefully