### PR TITLE
Support for the new longer ecs arn format

### DIFF
--- a/src/drain_lambda/drain.py
+++ b/src/drain_lambda/drain.py
@@ -33,6 +33,8 @@ def stop_daemon_tasks(cluster_arn, container_instance_arn, task_arns):
             arn:aws:ecs:us-east-1:111111111111:cluster/default
         container_instance_arn (str): container instance ARN, e.g.
             arn:aws:ecs:us-east-1:111111111111:container-instance/00c4a1c9-0c10-498b-b8c8-d5dc44c61ee0
+            or for newer stacks or if you have opted into the longer resource names
+            arn:aws:ecs:us-east-1:111111111111:container-instance/ClusterName/00c4a1c9-0c10-498b-b8c8-d5dc44c61ee0
         task_arns (list): ARNs of all tasks still running on the instance
     """
     short_arn = container_instance_arn.split('/')[-1]

--- a/src/drain_lambda/drain.py
+++ b/src/drain_lambda/drain.py
@@ -35,7 +35,7 @@ def stop_daemon_tasks(cluster_arn, container_instance_arn, task_arns):
             arn:aws:ecs:us-east-1:111111111111:container-instance/00c4a1c9-0c10-498b-b8c8-d5dc44c61ee0
         task_arns (list): ARNs of all tasks still running on the instance
     """
-    short_arn = container_instance_arn.split('/')[1]
+    short_arn = container_instance_arn.split('/')[-1]
     logger.info('Stopping default tasks on instance %s...',
                 short_arn)
 
@@ -246,7 +246,7 @@ def handler(event, context):
                 'Iteration': iteration
             })
         subject = 'Draining instance {}'.format(
-            container_instance_arn.split('/')[1])
+            container_instance_arn.split('/')[-1])
         publish_to_sns(message, subject, topic_arn)
         return
     else:


### PR DESCRIPTION
The format of ECS ARN's is changing.  
https://aws.amazon.com/ecs/faqs/#Transition_to_new_ARN_and_ID_format

The TLDR is that where the old format of the ARN of a container instance looked like
           ` arn:aws:ecs:us-east-1:111111111111:container-instance/00c4a1c9-0c10-498b-b8c8-d5dc44c61ee0`

the new format contains the cluster name, like this:
            `arn:aws:ecs:us-east-1:111111111111:container-instance/ClusterName/00c4a1c9-0c10-498b-b8c8-d5dc44c61ee0`

It's opt-in for existing accounts but if you do opt-in the draining lambda will no longer be able to stop tasks you've started manually on the instance as it ends out picking up the Cluster name rather than the instance id when looking for it in the new format ARNs
